### PR TITLE
Fix yargs command tests

### DIFF
--- a/test/commands/create-card.test.js
+++ b/test/commands/create-card.test.js
@@ -14,12 +14,14 @@ afterEach(() => {
 });
 
 test('`project:add-pull-request` command module exports an object that can be used by yargs', () => {
-    expect.objectContaining({
-        command: expect.stringMatching('project:add-pull-request'),
-        desc: expect.any(String),
-        builder: expect.any(Function),
-        handler: expect.any(Function)
-    });
+    expect(addPullRequestCommand).toEqual(
+        expect.objectContaining({
+            command: expect.stringMatching('project:add-pull-request'),
+            desc: expect.any(String),
+            builder: expect.any(Function),
+            handler: expect.any(Function)
+        })
+    );
 });
 
 test('yargs can load the `project:add-pull-request` command without any errors or warnings', () => {

--- a/test/commands/create-project.test.js
+++ b/test/commands/create-project.test.js
@@ -12,12 +12,14 @@ afterEach(() => {
 });
 
 test('`project:create` command module exports an object that can be used by yargs', () => {
-    expect.objectContaining({
-        command: expect.stringMatching('project:create'),
-        desc: expect.any(String),
-        builder: expect.any(Function),
-        handler: expect.any(Function)
-    });
+    expect(createProjectCommand).toEqual(
+        expect.objectContaining({
+            command: expect.stringMatching('project:create'),
+            desc: expect.any(String),
+            builder: expect.any(Function),
+            handler: expect.any(Function)
+        })
+    );
 });
 
 test('yargs can load the `project:create` command without any errors or warnings', () => {

--- a/test/commands/create-pull-request.test.js
+++ b/test/commands/create-pull-request.test.js
@@ -8,12 +8,14 @@ jest.spyOn(global.console, 'warn')
     .mockImplementation((message) => message);
 
 test('`pull-request:create` command module exports an object that can be used by yargs', () => {
-    expect.objectContaining({
-        command: expect.stringMatching('project:create'),
-        desc: expect.any(String),
-        builder: expect.any(Function),
-        handler: expect.any(Function)
-    });
+    expect(createPullRequestCommand).toEqual(
+        expect.objectContaining({
+            command: expect.stringMatching('pull-request:create'),
+            desc: expect.any(String),
+            builder: expect.any(Function),
+            handler: expect.any(Function)
+        })
+    );
 });
 
 test('yargs can load the `pull-request:create` command without any errors or warnings', () => {


### PR DESCRIPTION
They weren't actually making an assertion against the objects being exported by the command modules.

Resolves #5.