### PR TITLE
Set a default for --token option

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/rest": "^16.16.3",
+    "lodash.flow": "^3.5.0",
     "yargs": "^13.2.1"
   },
   "devDependencies": {

--- a/src/commands/create-card.js
+++ b/src/commands/create-card.js
@@ -1,4 +1,7 @@
+const flow = require('lodash.flow');
+
 const github = require("../lib/github");
+const { withToken } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -7,7 +10,9 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	return yargs
+	const baseOptions = flow(withToken);
+
+	return baseOptions(yargs)
 		.option("column", {
 			describe: "Project column ID",
 			demandOption: true,
@@ -17,11 +22,6 @@ const builder = yargs => {
 			describe: "Pull request ID",
 			demandOption: true,
 			type: "number"
-		})
-		.option("token", {
-			describe: "GitHub personal access token",
-			demandOption: true,
-			type: "string"
 		});
 };
 

--- a/src/commands/create-project.js
+++ b/src/commands/create-project.js
@@ -1,4 +1,7 @@
+const flow = require('lodash.flow');
+
 const github = require("../lib/github");
+const { withToken } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -7,7 +10,9 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	return yargs
+	const baseOptions = flow(withToken);
+
+	return baseOptions(yargs)
 		.option("org", {
 			alias: "o",
 			describe: "Organization",
@@ -17,11 +22,6 @@ const builder = yargs => {
 		.option("name", {
 			alias: "n",
 			describe: "Project name",
-			demandOption: true,
-			type: "string"
-		})
-		.option("token", {
-			describe: "GitHub personal access token",
 			demandOption: true,
 			type: "string"
 		});

--- a/src/commands/create-pull-request.js
+++ b/src/commands/create-pull-request.js
@@ -1,5 +1,8 @@
+const flow = require('lodash.flow');
 const fs = require("fs");
+
 const github = require("../lib/github");
+const { withToken } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -8,7 +11,9 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	return yargs
+	const baseOptions = flow(withToken);
+
+	return baseOptions(yargs)
 		.option("owner", {
 			alias: "o",
 			describe: "Owner",
@@ -39,11 +44,6 @@ const builder = yargs => {
 		})
 		.option("body", {
 			describe: "Path to pull request body",
-			type: "string"
-		})
-		.option("token", {
-			describe: "GitHub personal access token",
-			demandOption: true,
 			type: "string"
 		});
 };

--- a/src/lib/helpers/yargs/options.js
+++ b/src/lib/helpers/yargs/options.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-console */
+
+const withToken = yargs => {
+	return yargs.option("token", {
+		describe:
+			"GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one at https://github.com/settings/tokens.",
+		type: "string",
+		// IMPORTANT: We use a function here so the token is not output on the command line
+		default: () => process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
+		coerce: value => {
+			if (!value) {
+				throw new Error(
+					"Error: `--token` option is required as a valid GITHUB_PERSONAL_ACCESS_TOKEN environment variable does not exist"
+				);
+			}
+			return value;
+		}
+	});
+};
+
+module.exports = { withToken };


### PR DESCRIPTION
For a nicer developer experience, we're now using the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable as the default value for the `--token` option.

Resolves #13.