### PR TITLE
Make global `--json` option explicit

### DIFF
--- a/bin/github.js
+++ b/bin/github.js
@@ -3,5 +3,6 @@
 require("yargs")
 	.commandDir("../src/commands")
 	.demandCommand()
+	.group(['token', 'json'], 'Global Options:')
 	.strict()
 	.help().argv;

--- a/bin/github.js
+++ b/bin/github.js
@@ -3,8 +3,5 @@
 require("yargs")
 	.commandDir("../src/commands")
 	.demandCommand()
-	.option("json", {
-		type: "boolean"
-	})
 	.strict()
 	.help().argv;

--- a/src/commands/create-card.js
+++ b/src/commands/create-card.js
@@ -1,7 +1,7 @@
 const flow = require('lodash.flow');
 
 const github = require("../lib/github");
-const { withToken } = require("../lib/helpers/yargs/options");
+const { withToken, withJson } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -10,7 +10,7 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	const baseOptions = flow(withToken);
+	const baseOptions = flow([withToken, withJson]);
 
 	return baseOptions(yargs)
 		.option("column", {

--- a/src/commands/create-project.js
+++ b/src/commands/create-project.js
@@ -1,7 +1,7 @@
 const flow = require('lodash.flow');
 
 const github = require("../lib/github");
-const { withToken } = require("../lib/helpers/yargs/options");
+const { withToken, withJson } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -10,7 +10,7 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	const baseOptions = flow(withToken);
+	const baseOptions = flow([withToken, withJson]);
 
 	return baseOptions(yargs)
 		.option("org", {

--- a/src/commands/create-pull-request.js
+++ b/src/commands/create-pull-request.js
@@ -2,7 +2,7 @@ const flow = require('lodash.flow');
 const fs = require("fs");
 
 const github = require("../lib/github");
-const { withToken } = require("../lib/helpers/yargs/options");
+const { withToken, withJson } = require("../lib/helpers/yargs/options");
 const printOutput = require("../lib/helpers/print-output");
 
 /**
@@ -11,7 +11,7 @@ const printOutput = require("../lib/helpers/print-output");
  * @param {import('yargs').Yargs} yargs - Instance of yargs
  */
 const builder = yargs => {
-	const baseOptions = flow(withToken);
+	const baseOptions = flow([withToken, withJson]);
 
 	return baseOptions(yargs)
 		.option("owner", {

--- a/src/lib/helpers/yargs/options.js
+++ b/src/lib/helpers/yargs/options.js
@@ -18,4 +18,11 @@ const withToken = yargs => {
 	});
 };
 
-module.exports = { withToken };
+const withJson = yargs => {
+	return yargs.option("json", {
+		describe: "Format command output as JSON string",
+		type: "boolean"
+	});
+};
+
+module.exports = { withToken, withJson };


### PR DESCRIPTION
Having the `--json` option configured at a global level with `yargs` didn't feel particularly good in terms of making this project's codebase accessible to other developers (_"where does the json option that this command uses actually come from?"_), so I've followed the approach that [Ebi](https://github.com/Financial-Times/ebi) takes, and each command now explicitly defines the options that it accepts.

Resolves #38.