### PR TITLE
Fix CircleCI `publish` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
       - run:
           name: Bump package version
-          command: npm version ${CIRCLE_TAG}
+          command: npm version --no-git-tag-version ${CIRCLE_TAG}
       - run:
           name: Publish package to npm
           command: npm publish --access=public


### PR DESCRIPTION
We don't want `npm` to commit any changes when we use `npm version` to change the `version` field in `package.json`.

Related failing build: https://circleci.com/gh/Financial-Times/github/157