### PR TITLE
Link to a pre-filled GitHub token creation page

### DIFF
--- a/src/lib/helpers/yargs/options.js
+++ b/src/lib/helpers/yargs/options.js
@@ -2,7 +2,7 @@
 
 const descriptions = {
 	token:
-		"GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one at https://github.com/settings/tokens/new?scopes=repo,admin:org.",
+		"GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one at https://github.com/settings/tokens/new?scopes=repo,write:org.",
 	json: "Format command output as JSON string"
 };
 

--- a/src/lib/helpers/yargs/options.js
+++ b/src/lib/helpers/yargs/options.js
@@ -2,7 +2,7 @@
 
 const descriptions = {
 	token:
-		"GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one at https://github.com/settings/tokens.",
+		"GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one at https://github.com/settings/tokens/new?scopes=repo,admin:org.",
 	json: "Format command output as JSON string"
 };
 


### PR DESCRIPTION
This tool requires a couple of scopes to have permission for actions like creating a org level project board.